### PR TITLE
Fix saving of display settings across mode switches

### DIFF
--- a/piviewer.py
+++ b/piviewer.py
@@ -888,6 +888,23 @@ class DisplayWindow(QMainWindow):
             percent = 0
         self.spotify_progress_bar.setValue(int(percent))
 
+    # --- Async Spotify album art fetch helper used in tests ---
+    def start_spotify_fetch(self):
+        """Start a background thread to fetch album art if one isn't running."""
+        if getattr(self, "spotify_fetch_thread", None) and self.spotify_fetch_thread.is_alive():
+            return
+
+        self.spotify_fetch_id = getattr(self, "spotify_fetch_id", 0) + 1
+        fid = self.spotify_fetch_id
+
+        def runner():
+            result = self.fetch_spotify_album_art()
+            if hasattr(self, "handle_spotify_result"):
+                self.handle_spotify_result(fid, result)
+
+        self.spotify_fetch_thread = threading.Thread(target=runner, daemon=True)
+        self.spotify_fetch_thread.start()
+
     def pull_displays_from_remote(self, ip):
         pass  # Placeholder if needed
 

--- a/routes.py
+++ b/routes.py
@@ -522,14 +522,19 @@ def index():
             for dname in cfg["displays"]:
                 pre = dname + "_"
                 dcfg = cfg["displays"][dname]
-                new_mode = request.form.get(pre + "mode", dcfg["mode"])
-                new_interval_s = request.form.get(pre + "image_interval", str(dcfg["image_interval"]))
-                new_cat = request.form.get(pre + "image_category", dcfg["image_category"])
-                shuffle_val = request.form.get(pre + "shuffle_mode", "no")
-                new_spec = request.form.get(pre + "specific_image", dcfg["specific_image"])
-                rotate_str = request.form.get(pre + "rotate", "0")
-                mixed_str = request.form.get(pre + "mixed_order", "")
-                mixed_list = [x for x in mixed_str.split(",") if x]
+                new_mode = request.form.get(pre + "mode", dcfg.get("mode"))
+                new_interval_s = request.form.get(pre + "image_interval", str(dcfg.get("image_interval", 60)))
+                new_cat = request.form.get(pre + "image_category", dcfg.get("image_category", ""))
+                shuffle_val = request.form.get(pre + "shuffle_mode")
+                if shuffle_val is None:
+                    shuffle_val = "yes" if dcfg.get("shuffle_mode") else "no"
+                new_spec = request.form.get(pre + "specific_image", dcfg.get("specific_image", ""))
+                rotate_str = request.form.get(pre + "rotate", str(dcfg.get("rotate", 0)))
+                if pre + "mixed_order" in request.form:
+                    mixed_str = request.form.get(pre + "mixed_order", "")
+                    mixed_list = [x for x in mixed_str.split(",") if x]
+                else:
+                    mixed_list = dcfg.get("mixed_folders", [])
 
                 try:
                     new_interval = int(new_interval_s)
@@ -538,7 +543,7 @@ def index():
                 try:
                     new_rotate = int(rotate_str)
                 except:
-                    new_rotate = 0
+                    new_rotate = dcfg.get("rotate", 0)
 
                 dcfg["mode"] = new_mode
                 dcfg["image_interval"] = new_interval
@@ -568,10 +573,8 @@ def index():
                     except:
                         dcfg["spotify_progress_update_interval"] = 200
 
-                if new_mode == "mixed":
+                if new_mode == "mixed" or pre + "mixed_order" in request.form:
                     dcfg["mixed_folders"] = mixed_list
-                else:
-                    dcfg["mixed_folders"] = []
 
             save_config(cfg)
             try:

--- a/templates/index.html
+++ b/templates/index.html
@@ -102,7 +102,7 @@
           <!-- Note: The progress bar update interval has been removed from the web page -->
           {% endif %}
           <!-- Interval (only for random/mixed) -->
-          {% if dcfg.mode in ["random_image","mixed"] %}
+          {% if dcfg.mode in ["random_image","mixed"] or (dcfg.mode == "spotify" and dcfg.fallback_mode in ["random_image","mixed"]) %}
           <label>Interval (sec):</label><br>
           <input type="number" name="{{ dname }}_image_interval" value="{{ dcfg.image_interval }}">
           <br><br>
@@ -112,7 +112,7 @@
           <input type="number" name="{{ dname }}_rotate" value="{{ dcfg.rotate|default(0) }}">
           <br><br>
           <!-- Shuffle (only for random/mixed) -->
-          {% if dcfg.mode in ["random_image","mixed"] %}
+          {% if dcfg.mode in ["random_image","mixed"] or (dcfg.mode == "spotify" and dcfg.fallback_mode in ["random_image","mixed"]) %}
           <label>Shuffle?</label><br>
           <select name="{{ dname }}_shuffle_mode">
             <option value="yes" {% if dcfg.shuffle_mode %}selected{% endif %}>Yes</option>
@@ -121,7 +121,7 @@
           <br><br>
           {% endif %}
           <!-- Category (for random/specific) -->
-          {% if dcfg.mode in ["random_image","specific_image"] %}
+          {% if dcfg.mode in ["random_image","specific_image"] or (dcfg.mode == "spotify" and dcfg.fallback_mode in ["random_image","specific_image"]) %}
           <label>Category (subfolder):</label><br>
           <select name="{{ dname }}_image_category">
             <option value="" {% if not dcfg.image_category %}selected{% endif %}>All</option>
@@ -135,7 +135,7 @@
           <br><br>
           {% endif %}
           <!-- Mixed Folders UI -->
-          {% if dcfg.mode == "mixed" %}
+          {% if dcfg.mode == "mixed" or (dcfg.mode == "spotify" and dcfg.fallback_mode == "mixed") %}
           <label>Multiple Folders (drag to reorder):</label><br>
           <input type="text" placeholder="Search..." id="{{ dname }}_search" style="width:90%;"><br>
           <div style="display:flex; gap:10px; margin-top:10px;">
@@ -165,7 +165,7 @@
           <br>
           {% endif %}
           <!-- Specific Image selection -->
-          {% if dcfg.mode == "specific_image" %}
+          {% if dcfg.mode == "specific_image" or (dcfg.mode == "spotify" and dcfg.fallback_mode == "specific_image") %}
           <label>Select Image/GIF:</label><br>
           {% set fileList = display_images[dname] %}
           {% if fileList and fileList|length > 100 %}


### PR DESCRIPTION
## Summary
- keep previous shuffle and spotify options if form fields are missing
- expose fallback viewer options when monitor is in Spotify mode
- add `start_spotify_fetch` helper for async tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ee2f7c58832ba515c303e0908e71